### PR TITLE
Update MakeCert.exe link in the doc

### DIFF
--- a/aspnet/web-api/overview/security/working-with-ssl-in-web-api.md
+++ b/aspnet/web-api/overview/security/working-with-ssl-in-web-api.md
@@ -63,7 +63,7 @@ The **SslNegotiateCert** flag means IIS will accept a certificate from the clien
 
 ### Creating a Client Certificate for Testing
 
-For testing purposes, you can use [MakeCert.exe](https://msdn.microsoft.com/library/bfsktky3.aspx) to create a client certificate. First, create a test root authority:
+For testing purposes, you can use [MakeCert.exe](https://docs.microsoft.com/en-us/windows/desktop/SecCrypto/makecert) to create a client certificate. First, create a test root authority:
 
 [!code-console[Main](working-with-ssl-in-web-api/samples/sample4.cmd)]
 


### PR DESCRIPTION
MakeCert.exe is pointing to an old link which now says:
This topic is no longer available
The information in this topic is now moved to the following topic: https://msdn.microsoft.com/library/windows/desktop/aa386968.aspx.
Hence updating the link.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->